### PR TITLE
bug - retrospective view 에서 httpx 에 대한 전체 Exception 핸들링 추가

### DIFF
--- a/true-friend/main-app/retrospectives/views.py
+++ b/true-friend/main-app/retrospectives/views.py
@@ -22,6 +22,11 @@ class RetrospectiveView(LoginRequiredMixin, View):
         except httpx.HTTPStatusError as e:
             print(f"HTTP error occurred: {e}")
             response = []
+        except Exception as e:
+            print(f"An error occurred: {e}")
+            response = []
+        else:
+            response = response.json()
 
         # convert string datetime to real datetime object
         for element in response:


### PR DESCRIPTION
## Overview
- `retrospective` 앱 의 view 에서 `httpx` 를 통해 `generation_app` 에 요청을 보내는 부분에서 전체 `Exception` 에 대한 핸들링을 추가하였습니다.

## Change Log
- `main_app`/`retrospective`/`views.py`/`RetrospectiveView` /`get()` 함수에서 `Exception` 부분을 추가했습니다.

## To Reviewer
- 앱을 띄웠을때 routing error 가 발생하면 문의 부탁드립니다.

## Issue Tags
- Closed: #6 
